### PR TITLE
Use one argument constructor to create Key instances

### DIFF
--- a/src/main/scala/us/theatr/akka/quartz/QuartzActor.scala
+++ b/src/main/scala/us/theatr/akka/quartz/QuartzActor.scala
@@ -132,9 +132,9 @@ class QuartzActor extends Actor {
 		case AddCronSchedule(to, cron, message, reply, spigot) =>
 			// Try to derive a unique name for this job
 			// Using hashcode is odd, suggestions for something better?
-			val jobkey = new JobKey(Key.DEFAULT_GROUP, "%X".format((to.toString() + message.toString + cron + "job").hashCode))
+			val jobkey = new JobKey("%X".format((to.toString() + message.toString + cron + "job").hashCode))
 			// Perhaps just a string is better :)
-			val trigkey = new TriggerKey(Key.DEFAULT_GROUP, to.toString() + message.toString + cron + "trigger")
+			val trigkey = new TriggerKey(to.toString() + message.toString + cron + "trigger")
 			// We use JobDataMaps to pass data to the newly created job runner class
 			val jd = org.quartz.JobBuilder.newJob(classOf[QuartzIsNotScalaExecutor])
 			val jdm = new JobDataMap()


### PR DESCRIPTION
This will effectively set the group name of each key to
org.quartz.utils.Key.DEFAULT_GROUP

Fixes theatrus/akka-quartz#3
