### PR TITLE
correctly serialize the log statement

### DIFF
--- a/src/main/scala/us/theatr/akka/quartz/QuartzActor.scala
+++ b/src/main/scala/us/theatr/akka/quartz/QuartzActor.scala
@@ -153,7 +153,7 @@ class QuartzActor extends Actor {
 
 			} catch { // Quartz will drop a throwable if you give it an invalid cron expression - pass that info on
 				case e: Throwable =>
-					log.error("Quartz failed to add a task: ", e)
+					log.error("Quartz failed to add a task: {}", e)
 					if (reply)
 						context.sender ! AddCronScheduleFailure(e)
 


### PR DESCRIPTION
This will correctly serialize the error into the log statement per the latest Akka placeholder convention.

There may be regression issues in older versions. I'd be glad to look into them if you find any.